### PR TITLE
Temporary fix for the broken light

### DIFF
--- a/output.php
+++ b/output.php
@@ -1,6 +1,6 @@
 <?php
 $sampleSize = 5;
-$threshold = 500;
+$threshold = 300;
 
 /*
 Aufruf -> Ausgabe


### PR DESCRIPTION
Due to the front light being broken, our current graph looks like this:

<img width="1288" alt="bildschirmfoto 2016-10-19 um 08 47 08" src="https://cloud.githubusercontent.com/assets/9332912/19508355/1a641eac-95d9-11e6-9c39-ef892e0f62b2.png">

Therefore I propose the temporary adjustment of the light `$threshold` to 300 so that people can see if someone's there, even with the first light being broken.
